### PR TITLE
feat: Implement basic health check endpoint

### DIFF
--- a/docs/Jules_tasks.md
+++ b/docs/Jules_tasks.md
@@ -14,7 +14,8 @@ Each task is a complete, focused implementation that an AI agent can finish in 5
 
 ### **Health & Monitoring System**
 
-- [ ] **Task 1: Implement Basic Health Check Endpoint**
+- [x] **Task 1: Implement Basic Health Check Endpoint**
+  - **Completion Status:** Implemented the `/api/health` endpoint, which returns JSON with status, version, uptime, and database connectivity status. Added integration tests.
   - **Branch:** `feature/health-check-endpoint`
   - **Time:** 8 minutes
   - **Files:** Create [`src/api/routes/health.rs`](src/api/routes/health.rs), update [`src/api/routes/mod.rs`](src/api/routes/mod.rs)

--- a/src/api/routes/health.rs
+++ b/src/api/routes/health.rs
@@ -1,0 +1,49 @@
+use actix_web::{web, HttpResponse, Responder};
+use serde::Serialize;
+use sqlx::PgPool;
+use std::time::Instant;
+
+// To store the application start time
+lazy_static::lazy_static! {
+    static ref START_TIME: Instant = Instant::now();
+}
+
+#[derive(Serialize)]
+struct HealthResponse {
+    status: String,
+    version: String,
+    uptime: String,
+    database_status: String,
+}
+
+async fn health_check(pool: web::Data<PgPool>) -> impl Responder {
+    let version = env!("CARGO_PKG_VERSION").to_string();
+    let uptime = START_TIME.elapsed().as_secs_f64().to_string() + " seconds";
+
+    let db_status = match pool.acquire().await {
+        Ok(mut conn) => {
+            match sqlx::query("SELECT 1").execute(&mut *conn).await {
+                Ok(_) => "OK".to_string(),
+                Err(e) => {
+                    log::error!("Database ping failed: {}", e);
+                    "Error".to_string()
+                }
+            }
+        }
+        Err(e) => {
+            log::error!("Failed to acquire database connection: {}", e);
+            "Error".to_string()
+        }
+    };
+
+    HttpResponse::Ok().json(HealthResponse {
+        status: "OK".to_string(),
+        version,
+        uptime,
+        database_status: db_status,
+    })
+}
+
+pub fn configure(cfg: &mut web::ServiceConfig) {
+    cfg.route("/api/health", web::get().to(health_check));
+}

--- a/src/api/routes/mod.rs
+++ b/src/api/routes/mod.rs
@@ -1,18 +1,20 @@
 
 pub mod user_routes;
 pub mod admin;
+pub mod health; // Added health module
 
 pub use admin::configure as configure_admin_routes;
 
 pub mod route_config {
     use actix_web::web;
     use log::debug;
-    use super::{user_routes, configure_admin_routes};
+    use super::{user_routes, health, configure_admin_routes}; // Added health module to use statement
 
     pub fn configure_all(cfg: &mut web::ServiceConfig) {
         debug!("Configuring all routes");
         user_routes::configure(cfg);
-        debug!("User routes configured, now configuring admin routes");
+        health::configure(cfg); // Added health route configuration
+        debug!("User and health routes configured, now configuring admin routes");
         configure_admin_routes(cfg);
         debug!("All routes configured");
     }

--- a/tests/health_check_tests.rs
+++ b/tests/health_check_tests.rs
@@ -1,0 +1,67 @@
+use actix_web::{test, App};
+use oxidizedoasis_websands::api::routes::route_config::configure_all;
+use oxidizedoasis_websands::infrastructure::database::connection::create_pool;
+use serde_json::Value;
+
+#[actix_rt::test]
+async fn test_health_check_endpoint() {
+    // Load .env file for database URL and other configurations
+    dotenv::dotenv().ok();
+
+    let db_pool = create_pool().await.expect("Failed to create database pool for test");
+
+    let mut app = test::init_service(
+        App::new()
+            .app_data(actix_web::web::Data::new(db_pool.clone()))
+            .configure(configure_all)
+    ).await;
+
+    let req = test::TestRequest::get().uri("/api/health").to_request();
+    let resp = test::call_service(&mut app, req).await;
+
+    assert!(resp.status().is_success(), "Response status should be 2xx");
+
+    let body: Value = test::read_body_json(resp).await;
+
+    assert_eq!(body["status"], "OK", "Status should be OK");
+    assert!(body["version"].as_str().is_some(), "Version should be a string");
+    assert!(body["uptime"].as_str().is_some(), "Uptime should be a string");
+
+    // Check database status specifically
+    // This implicitly tests database connectivity if the main health_check logic includes a ping
+    assert_eq!(body["database_status"], "OK", "Database status should be OK");
+}
+
+#[actix_rt::test]
+async fn test_database_connectivity_via_health_check() {
+    // Load .env file
+    dotenv::dotenv().ok();
+
+    let db_pool = create_pool().await.expect("Failed to create database pool for test");
+
+    // Test a simple query
+    let result = sqlx::query("SELECT 1 as id")
+        .fetch_one(&db_pool)
+        .await;
+
+    assert!(result.is_ok(), "Database query failed: {:?}", result.err());
+    // You could also check the value if needed:
+    // use sqlx::Row;
+    // let row = result.unwrap();
+    // assert_eq!(row.get::<i32, _>("id"), 1);
+
+    // Now, ensure the health check reports the DB as OK
+    let mut app = test::init_service(
+        App::new()
+            .app_data(actix_web::web::Data::new(db_pool.clone()))
+            .configure(configure_all)
+    ).await;
+
+    let req = test::TestRequest::get().uri("/api/health").to_request();
+    let resp = test::call_service(&mut app, req).await;
+
+    assert!(resp.status().is_success(), "Health check response status should be 2xx");
+
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["database_status"], "OK", "Health check should report database_status as OK");
+}

--- a/tests/user_tests.rs
+++ b/tests/user_tests.rs
@@ -1,0 +1,1 @@
+mod health_check_tests;


### PR DESCRIPTION
Adds a new endpoint `/api/health` that returns a JSON response containing the application's status, version, uptime, and the status of the database connection.

The implementation includes:
- A new route handler in `src/api/routes/health.rs`.
- Updates to `src/api/routes/mod.rs` to integrate the new route.
- Integration tests in `tests/health_check_tests.rs` to verify:
    - Successful 200 OK response from the endpoint.
    - Correct JSON structure and content.
    - Database connectivity via a ping within the health check.

The application start time is tracked using `lazy_static` to calculate uptime. Error handling for database connection acquisition and ping is included. The `docs/Jules_tasks.md` file has been updated to reflect the completion of this task.